### PR TITLE
Require run_id for environments

### DIFF
--- a/examples/claude_osworld.ipynb
+++ b/examples/claude_osworld.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# it may take around 3 minutes to initialize the OSWorld platform and reset to a task\n",
+    "# it may take around 1-2 minutes to initialize the OSWorld platform and reset to a task\n",
     "\n",
     "# make a HUD environment\n",
     "env = await run.make()\n",

--- a/hud/environment.py
+++ b/hud/environment.py
@@ -75,7 +75,7 @@ class Environment:
     def __init__(
         self,
         adapter: Adapter,
-        run_id: str | None = None,
+        run_id: str,
         id: str | None = None,
         config: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -85,7 +85,7 @@ class Environment:
         
         Args:
             adapter: Adapter for converting actions
-            run_id: Optional ID of the run this environment belongs to
+            run_id: ID of the run this environment belongs to
             id: Optional ID of an existing environment
             config: Optional configuration parameters
             metadata: Optional metadata for the environment
@@ -98,8 +98,6 @@ class Environment:
         self.config = config
         self.adapter = adapter
         self.metadata = metadata
-        # task_run_id is created when the environment is created (create_environment)
-        # or provided if env already exists.
         self.final_response: None | str = None
         self.id = id
         self.vnc_url = None


### PR DESCRIPTION
- Require run_id for environments
- Deprecated comments cleanup