### PR TITLE
Add BibTex Citation at the bottom of readme for academics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ For comprehensive guides, examples, and API reference, visit [our docs](https://
 If you use this SDK in your research, please cite it as follows:
 
 ```bibtex
-@misc{HUD_SDK_2025,
+@software{HUD_SDK_2025,
   author       = {{HUD}},
   title        = {{HUD SDK}},
-  year         = {2025},
+  year         = {2025-03},
   howpublished = {\url{https://github.com/Human-Data/hud-sdk}}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,3 +66,16 @@ For comprehensive guides, examples, and API reference, visit [our docs](https://
 ## License
 
 [MIT License](LICENSE)
+
+## Citation
+
+If you use this SDK in your research, please cite it as follows:
+
+```bibtex
+@misc{HUD_SDK_2025,
+  author       = {{HUD}},
+  title        = {{HUD SDK}},
+  year         = {2025},
+  howpublished = {\url{https://github.com/Human-Data/hud-sdk}}
+}
+```

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ If you use this SDK in your research, please cite it as follows:
 
 ```bibtex
 @software{HUD_SDK_2025,
-  author       = {{HUD}},
-  title        = {{HUD SDK}},
-  year         = {2025-03},
-  howpublished = {\url{https://github.com/Human-Data/hud-sdk}}
+  author = {{HUD}},
+  title = {{HUD SDK}},
+  date = {2025-03},
+  url = {https://github.com/Human-Data/hud-sdk},
+  langid = {en}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use this SDK in your research, please cite it as follows:
 ```bibtex
 @software{hud2025agentevalplatform,
   author = {HUD and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},
-  title = {{HUD: An Agent Evaluation Platform for Computer Use Agents}},
+  title = {{HUD: An Evaluation Platform for Computer Use Agents}},
   date = {2025-03},
   url = {https://github.com/Human-Data/hud-sdk},
   langid = {en}

--- a/README.md
+++ b/README.md
@@ -71,14 +71,6 @@ For comprehensive guides, examples, and API reference, visit [our docs](https://
 
 If you use this SDK in your research, please cite it as follows:
 
-## Citation
-
-If you use this SDK in your research, please cite it as follows:
-
-## Citation
-
-If you use this SDK in your research, please cite it as follows:
-
 ```bibtex
 @software{hud2025agentevalplatform,
   author = {HUD and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},

--- a/README.md
+++ b/README.md
@@ -71,10 +71,18 @@ For comprehensive guides, examples, and API reference, visit [our docs](https://
 
 If you use this SDK in your research, please cite it as follows:
 
+## Citation
+
+If you use this SDK in your research, please cite it as follows:
+
+## Citation
+
+If you use this SDK in your research, please cite it as follows:
+
 ```bibtex
-@software{HUD_SDK_2025,
-  author = {{HUD}},
-  title = {{HUD SDK}},
+@software{hud2025agentevalplatform,
+  author = {HUD and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},
+  title = {{HUD: Agent Evaluation Platform for Computer Use Agents}},
   date = {2025-03},
   url = {https://github.com/Human-Data/hud-sdk},
   langid = {en}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use this SDK in your research, please cite it as follows:
 ```bibtex
 @software{hud2025agentevalplatform,
   author = {HUD and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},
-  title = {{HUD: Agent Evaluation Platform for Computer Use Agents}},
+  title = {{HUD: An Agent Evaluation Platform for Computer Use Agents}},
   date = {2025-03},
   url = {https://github.com/Human-Data/hud-sdk},
   langid = {en}


### PR DESCRIPTION
Changes below. I recommend:

1. Changing the authors to include team member names
2. Changing the name to "HUD: An Evaluation Platform for Computer Use Agents" [from the HUD homepage](https://www.hud.so/)

Adapted from citations of:

- [Inspect Framework](https://inspect.aisi.org.uk/#citation) for overall format
- [EleutherAI Eval Harness](https://github.com/EleutherAI/lm-evaluation-harness) for overall vibes
- [Chatbot Arena](https://arxiv.org/abs/2403.04132) for naming convention
- [DeepSeek](https://arxiv.org/abs/2501.12948) for putting HUD at the front

# With recommended changes:

## Citation

If you use this SDK in your research, please cite it as follows:

```bibtex
@software{hud2025agentevalplatform,
  author = {HUD and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},
  title = {{HUD: An Evaluation Platform for Computer Use Agents}},
  date = {2025-03},
  url = {https://github.com/Human-Data/hud-sdk},
  langid = {en}
}
```

# If you wanna be a little cheeky and make Human Data the inline citation:

## Citation

If you use this SDK in your research, please cite it as follows:

```bibtex
@software{hud2025agentevalplatform,
  author = {Human Data and Jay Ram and Lorenss Martinsons and Parth Patel and Max Muoto and Oskars Putans and Govind Pimpale and Mayank Singamreddy and Nguyen Nhat Minh},
  title = {{HUD: An Evaluation Platform for Computer Use Agents}},
  date = {2025-03},
  url = {https://github.com/Human-Data/hud-sdk},
  langid = {en}
}
```

# Basic citation (purely w Github):

## Citation

If you use this SDK in your research, please cite it as follows:

```bibtex
@software{HUD_SDK_2025,
  author = {{HUD}},
  title = {{HUD SDK}},
  date = {2025-03},
  url = {https://github.com/Human-Data/hud-sdk},
  langid = {en}
}
```